### PR TITLE
Various fixes and improvements for spree_paypal_express

### DIFF
--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -253,7 +253,8 @@ CheckoutController.class_eval do
       credits_total = credits.map {|i| i[:amount] * i[:quantity] }.sum
     end
 
-    opts = { :return_url        => request.protocol + request.host_with_port + "/orders/#{order.number}/checkout/paypal_confirm?payment_method_id=#{payment_method}",
+    opts = { #:return_url        => request.protocol + request.host_with_port + "/orders/#{order.number}/checkout/paypal_confirm?payment_method_id=#{payment_method}",
+             :return_url        => "http://"  + request.host_with_port + "/orders/#{order.number}/checkout/paypal_confirm?payment_method_id=#{payment_method}",
              :cancel_return_url => "http://"  + request.host_with_port + "/orders/#{order.number}/edit",
              :order_id          => order.number,
              :custom            => order.number,

--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -150,6 +150,7 @@ CheckoutController.class_eval do
       #need to force checkout to complete state
       until @order.state == "complete"
         if @order.next!
+          @order.update!
           state_callback(:after)
         end
       end
@@ -226,7 +227,7 @@ CheckoutController.class_eval do
       { :name        => item.variant.product.name,
         :description => item.variant.product.description[0..120],
         :sku         => item.variant.sku,
-        :qty         => item.quantity,
+        :quantity    => item.quantity,
         :amount      => price,
         :weight      => item.variant.weight,
         :height      => item.variant.height,
@@ -239,7 +240,7 @@ CheckoutController.class_eval do
         { :name        => credit.label,
           :description => credit.label,
           :sku         => credit.id,
-          :qty         => 1,
+          :quantity    => 1,
           :amount      => (credit.amount*100).to_i }
       end
     end
@@ -248,7 +249,7 @@ CheckoutController.class_eval do
     credits.compact!
     if credits.present?
       items.concat credits
-      credits_total = credits.map {|i| i[:amount] * i[:qty] }.sum
+      credits_total = credits.map {|i| i[:amount] * i[:quantity] }.sum
     end
 
     opts = { :return_url        => request.protocol + request.host_with_port + "/orders/#{order.number}/checkout/paypal_confirm?payment_method_id=#{payment_method}",


### PR DESCRIPTION
## The following fixes and improvements are included:
- fixed 'The totals of the cart item amounts do not match order amounts.' error with patch http://pastie.org/1731543, also see https://groups.google.com/group/spree-user/browse_thread/thread/7a20e9c8440980f8/e334785b4e920596
- fixed display of tax amount on PayPal site, tax and shipping displayed seperately (tax should perhaps be set differently, see checkout_controller_decorator.rb, line 267)
- by joshnuss: fixed logo image url passed to paypal
- by joshnuss: logo image should use Spree::Config setting
- by joshnuss: save bill address during checkout if it is empty
- by schustafa: Product descriptions can be nil without disrupting checkout.
