### PR TITLE
store_credits extension breaks with paypal_express extension

### DIFF
--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -178,6 +178,7 @@ CheckoutController.class_eval do
 
   def redirect_to_paypal_express_form_if_needed
     return unless (params[:state] == "payment")
+    return unless params[:order][:payments_attributes]
     if params[:order][:coupon_code]
       @order.update_attributes(object_params)
       @order.process_coupon_code


### PR DESCRIPTION
redirect_to_paypal_express_form_if_needed needs to check it's params before calling .first on them. 
