### PR TITLE
Fix issues: #16 and #13

### DIFF
--- a/Versionfile
+++ b/Versionfile
@@ -1,3 +1,3 @@
-"0.70.x" => { :branch => "master" }
+"0.70.x" => { :branch => "fix-process_coupon_code-#16" }
 "0.60.x" => { :ref => "073f2f814dd8f3ad2e66ddde2c7079d8c76e4d27" }
 "0.50.x" => { :ref => "39a3b00602d591e5c27bf13941aa5c13e4b95579" }

--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -25,7 +25,7 @@ CheckoutController.class_eval do
     redirect_to :back
   end
 
-  def paypal_payment
+  def paypal_payment    
     load_order
     opts = all_opts(@order,params[:payment_method_id], 'payment')
     opts.merge!(address_options(@order))
@@ -49,7 +49,7 @@ CheckoutController.class_eval do
     redirect_to :back
   end
 
-  def paypal_confirm 
+  def paypal_confirm  
     load_order
 
     opts = { :token => params[:token], :payer_id => params[:PayerID] }.merge all_opts(@order, params[:payment_method_id],  'payment')
@@ -109,7 +109,7 @@ CheckoutController.class_eval do
     redirect_to edit_order_url(@order)
   end
 
-  def paypal_finish
+  def paypal_finish 
     load_order
 
     opts = { :token => params[:token], :payer_id => params[:PayerID] }.merge all_opts(@order, params[:payment_method_id], 'payment' )
@@ -160,7 +160,7 @@ CheckoutController.class_eval do
       redirect_to completion_route
 
     else
-      payment.fail!
+      payment.failure!
       order_params = {}
       gateway_error(ppx_auth_response)
 
@@ -178,8 +178,7 @@ CheckoutController.class_eval do
     payment.log_entries.create(:details => response.to_yaml)
   end
 
-  def redirect_to_paypal_express_form_if_needed  
-    debugger  
+  def redirect_to_paypal_express_form_if_needed    
     return unless (params[:state] == "payment")
     return unless params[:order][:payments_attributes]
     if params[:order][:coupon_code]

--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -185,13 +185,14 @@ CheckoutController.class_eval do
       @order.update_attributes(object_params)
       #@order.process_coupon_code # old code pre 0.70.x    
       
-      # as in spree_promo 0.70.1 orders_controller_decorator.rb :  
+      # as in spree_promo 0.70 orders_controller_decorator.rb :  
       if @order.coupon_code.present?
         fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
       end
     end 
     @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
     fire_event('spree.order.contents_changed')   
+    ### end patch for 0.70
     
     load_order
     payment_method = PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])

--- a/app/controllers/checkout_controller_decorator.rb
+++ b/app/controllers/checkout_controller_decorator.rb
@@ -49,7 +49,7 @@ CheckoutController.class_eval do
     redirect_to :back
   end
 
-  def paypal_confirm
+  def paypal_confirm 
     load_order
 
     opts = { :token => params[:token], :payer_id => params[:PayerID] }.merge all_opts(@order, params[:payment_method_id],  'payment')
@@ -178,13 +178,22 @@ CheckoutController.class_eval do
     payment.log_entries.create(:details => response.to_yaml)
   end
 
-  def redirect_to_paypal_express_form_if_needed
+  def redirect_to_paypal_express_form_if_needed  
+    debugger  
     return unless (params[:state] == "payment")
     return unless params[:order][:payments_attributes]
     if params[:order][:coupon_code]
       @order.update_attributes(object_params)
-      @order.process_coupon_code
-    end
+      #@order.process_coupon_code # old code pre 0.70.x    
+      
+      # as in spree_promo 0.70.1 orders_controller_decorator.rb :  
+      if @order.coupon_code.present?
+        fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
+      end
+    end 
+    @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
+    fire_event('spree.order.contents_changed')   
+    
     load_order
     payment_method = PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
 

--- a/app/controllers/paypal_express_callbacks_controller.rb
+++ b/app/controllers/paypal_express_callbacks_controller.rb
@@ -17,7 +17,7 @@ class PaypalExpressCallbacksController < Spree::BaseController
 
       case @notification.params["payment_status"]
         when "Denied"
-          @payment.fail!
+          @payment.failure!
 
         when "Completed"
           @payment.complete!


### PR DESCRIPTION
I fixed problems with process_coupon_code and fail! calls, issues #13 and #16.

But there's another error updating an order with a credit coupon_code because shipment adjustment has amount == nil in update_totals, line 468: self.adjustment_total = adjustments.eligible.map(&:amount).sum .

NoMethodError in CheckoutController#paypal_confirm

You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.+

Rails.root: /Users/matteo/Development/RubyOnRails/docg
Application Trace | Framework Trace | Full Trace

activesupport (3.1.1) lib/active_support/core_ext/enumerable.rb:61:in `block in sum'
activesupport (3.1.1) lib/active_support/core_ext/enumerable.rb:61:in`each'
activesupport (3.1.1) lib/active_support/core_ext/enumerable.rb:61:in `inject'
activesupport (3.1.1) lib/active_support/core_ext/enumerable.rb:61:in`sum'
spree_core (0.70.1) app/models/order.rb:468:in `update_totals'
spree_core (0.70.1) app/models/order.rb:149:in`update!'
spree_core (0.70.1) app/models/payment.rb:110:in `update_order'
