### PR TITLE
undefined class ActiveMerchant::Billing::PaypalExpressResponse

### DIFF
--- a/config/initializers/paypal_express.rb
+++ b/config/initializers/paypal_express.rb
@@ -1,0 +1,1 @@
+require 'active_merchant/billing/gateways/paypal_express'


### PR DESCRIPTION
added initializer to require appropriate ActiveMerchant files

[fixes #32]
