### PR TITLE
Fixed missing namespacing for Spree 1.0.x (Order became Spree::Order)

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -258,8 +258,8 @@ module Spree
                :custom            => order.number,
                :items             => items,
                :subtotal          => ((order.item_total * 100) + credits_total).to_i,
-               :tax               => ((order.adjustments.map { |a| a.amount if ( a.source_type == 'Order' && a.label == 'Tax') }.compact.sum) * 100 ).to_i,
-               :shipping          => ((order.adjustments.map { |a| a.amount if a.source_type == 'Shipment' }.compact.sum) * 100 ).to_i,
+               :tax               => ((order.adjustments.map { |a| a.amount if a.originator == 'Spree::TaxRate' }.compact.sum) * 100 ).to_i,
+               :shipping          => ((order.adjustments.map { |a| a.amount if a.source_type == 'Spree::Shipment' }.compact.sum) * 100 ).to_i,
                :money             => (order.total * 100 ).to_i }
 
         # add correct tax amount by subtracting subtotal and shipping otherwise tax = 0 -> need to check adjustments.map


### PR DESCRIPTION
Also changed the check on taxes: using originator_type instead of Adjusment label makes it better for internationalization (we can give any name to the tax instead of 'Tax' and works just fine now)

[Fixes #40]
