### PR TITLE
fixes asset_url failing if logo is absolute url

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -200,7 +200,6 @@ module Spree
       { :description             => "Goods from #{Spree::Config[:site_name]}", # site details...
 
         #:page_style             => "foobar", # merchant account can set named config
-        :header_image            => asset_url(Spree::Config[:logo]),
         :background_color        => "ffffff",  # must be hex only, six chars
         :header_background_color => "ffffff",
         :header_border_color     => "ffffff",
@@ -213,6 +212,13 @@ module Spree
         # they've not been tested and may trigger some paypal bugs, eg not showing order
         # see http://www.pdncommunity.com/t5/PayPal-Developer-Blog/Displaying-Order-Details-in-Express-Checkout/bc-p/92902#C851
       }
+	#asset_url doesn't like Spree::Config[:logo] being an absolute url
+	#if statement didn't work within hash
+	if URI.parse(Spree::Config[:logo]).absolute?
+	  {:header_image => Spree::Config[:logo]}
+	else
+	  {:header_image => asset_url(Spree::Config[:logo])}
+	end
     end
 
     def user_locale


### PR DESCRIPTION
Fixes https://github.com/spree/spree_paypal_express/issues/52

Tested by hand using:
Spree::Config.set(:logo => 'http://s3.amazonaws.com/rkbb-prod/site/roots_logo.png')
Spree::Config.set(:logo => 'rails.png')

Please check before pulling... it maybe simple to everyone else here, but I'm new to this ;-)
