### PR TITLE
fixes asset_url failing if logo is absolute url (Iss52fix v2)

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -195,14 +195,22 @@ module Spree
       else
         user_action = Spree::PaypalExpress::Config[:paypal_express_local_confirm] == "t" ? "continue" : "commit"
       end
+      
+      #asset_url doesn't like Spree::Config[:logo] being an absolute url
+      #if statement didn't work within hash
+      if URI.parse(Spree::Config[:logo]).absolute?
+          chosen_image = Spree::Config[:logo]
+      else
+          chosen_image = asset_url(Spree::Config[:logo])
+      end
 
 
       { :description             => "Goods from #{Spree::Config[:site_name]}", # site details...
-
         #:page_style             => "foobar", # merchant account can set named config
         :background_color        => "ffffff",  # must be hex only, six chars
         :header_background_color => "ffffff",
         :header_border_color     => "ffffff",
+	:header_image		 => chosen_image
         :allow_note              => true,
         :locale                  => user_locale,
         :req_confirm_shipping    => false,   # for security, might make an option later
@@ -212,13 +220,6 @@ module Spree
         # they've not been tested and may trigger some paypal bugs, eg not showing order
         # see http://www.pdncommunity.com/t5/PayPal-Developer-Blog/Displaying-Order-Details-in-Express-Checkout/bc-p/92902#C851
       }
-	#asset_url doesn't like Spree::Config[:logo] being an absolute url
-	#if statement didn't work within hash
-	if URI.parse(Spree::Config[:logo]).absolute?
-	  {:header_image => Spree::Config[:logo]}
-	else
-	  {:header_image => asset_url(Spree::Config[:logo])}
-	end
     end
 
     def user_locale

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -200,7 +200,6 @@ module Spree
       { :description             => "Goods from #{Spree::Config[:site_name]}", # site details...
 
         #:page_style             => "foobar", # merchant account can set named config
-        :header_image            => asset_url(Spree::Config[:logo]),
         :background_color        => "ffffff",  # must be hex only, six chars
         :header_background_color => "ffffff",
         :header_border_color     => "ffffff",
@@ -213,6 +212,13 @@ module Spree
         # they've not been tested and may trigger some paypal bugs, eg not showing order
         # see http://www.pdncommunity.com/t5/PayPal-Developer-Blog/Displaying-Order-Details-in-Express-Checkout/bc-p/92902#C851
       }
+	#asset_url doesn't like Spree::Config[:logo] being an absolute url
+	#if statement didn't work within hash
+	if URI.parse(Spree::Config[:logo]).absolute?
+	  {:header_image => Spree::Config[:logo]}
+	else
+	  {:header_image => asset_url(Spree::Config[:logo])}
+	end
     end
 
     def user_locale

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -210,7 +210,7 @@ module Spree
         :background_color        => "ffffff",  # must be hex only, six chars
         :header_background_color => "ffffff",
         :header_border_color     => "ffffff",
-	:header_image		 => chosen_image
+	:header_image		 => chosen_image,
         :allow_note              => true,
         :locale                  => user_locale,
         :req_confirm_shipping    => false,   # for security, might make an option later


### PR DESCRIPTION
Reworked version following Radars feedback.

PS: I'm still new to this... if there's a way of combining all my workings into a single commit please point me in the right direction so I know for future. I'm guess I'm not the only one who misses a comma!
