### PR TITLE
Update app/controllers/spree/checkout_controller_decorator.rb

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -177,10 +177,14 @@ module Spree
     def redirect_to_paypal_express_form_if_needed
       return unless (params[:state] == "payment")
       return unless params[:order][:payments_attributes]
+
       if params[:order][:coupon_code]
         @order.update_attributes(object_params)
-        @order.process_coupon_code
+        if @order.coupon_code.present?
+          fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
+        end
       end
+      
       load_order
       payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
 


### PR DESCRIPTION
fix undefined method `process_coupon_code' on master branch. This is my first pull request so sorry if this isn't done right. I just copied the method redirect_to_paypal_express_form_if_needed from branch 1-0-stable.
