### PR TITLE
Setting the order.state to 'confirm' if in paypal_confirm view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'sqlite3-ruby', :require => 'sqlite3'
+gem 'sqlite3'
 gem 'spree', :path => '../spree'
 
 group :test do

--- a/Versionfile
+++ b/Versionfile
@@ -1,4 +1,5 @@
-"1.0.0"  => { :branch => "master" }
+"1.1.0"  => { :branch => "1-1-stable" }
+"1.0.0"  => { :branch => "1-0-stable" }
 "0.70.x" => { :ref => "bea1aa48e0089083546bec4b19565a40e9a50a20" }
 "0.60.x" => { :ref => "073f2f814dd8f3ad2e66ddde2c7079d8c76e4d27" }
 "0.50.x" => { :ref => "39a3b00602d591e5c27bf13941aa5c13e4b95579" }

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -80,7 +80,7 @@ module Spree
                                                   # phone is currently blanked in AM's PPX response lib
                                                   :phone      => @ppx_details.params["phone"] || "(not given)"
 
-          if (state = Spree::State.find_by_abbr(ship_address["state"]))
+          if (state = Spree::State.find_by_abbr(ship_address["state"].upcase))
             order_ship_address.state = state
           else
             order_ship_address.state_name = ship_address["state"]

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -80,7 +80,8 @@ module Spree
                                                   # phone is currently blanked in AM's PPX response lib
                                                   :phone      => @ppx_details.params["phone"] || "(not given)"
 
-          if (state = Spree::State.find_by_abbr(ship_address["state"].upcase))
+          state = Spree::State.find_by_abbr(ship_address["state"].upcase) if ship_address["state"].present?
+          if state
             order_ship_address.state = state
           else
             order_ship_address.state_name = ship_address["state"]

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -90,11 +90,13 @@ module Spree
           @order.ship_address = order_ship_address
           @order.bill_address ||= order_ship_address
         end
-        @order.save
 
         if payment_method.preferred_review
+          @order.state = "confirm"
+          @order.save
           render 'spree/shared/paypal_express_confirm'
         else
+          @order.save
           paypal_finish
         end
 
@@ -189,7 +191,7 @@ module Spree
           fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
         end
       end
-      
+
       load_order
       payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
 

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -80,7 +80,7 @@ module Spree
                                                   # phone is currently blanked in AM's PPX response lib
                                                   :phone      => @ppx_details.params["phone"] || "(not given)"
 
-          if (state = Spree::State.find_by_abbr(ship_address["state"].upcase))
+          if (state = Spree::State.find_by_abbr(ship_address["state"].try(:upcase)))
             order_ship_address.state = state
           else
             order_ship_address.state_name = ship_address["state"]

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -240,7 +240,7 @@ module Spree
         price = (item.price * 100).to_i # convert for gateway
         { :name        => item.variant.product.name,
           :description => (item.variant.product.description[0..120] if item.variant.product.description),
-          :sku         => item.variant.sku,
+          :number      => item.variant.sku,
           :quantity    => item.quantity,
           :amount      => price,
           :weight      => item.variant.weight,

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -80,7 +80,7 @@ module Spree
                                                   # phone is currently blanked in AM's PPX response lib
                                                   :phone      => @ppx_details.params["phone"] || "(not given)"
 
-          if (state = Spree::State.find_by_abbr(ship_address["state"].try(:upcase)))
+          if (state = Spree::State.find_by_abbr(ship_address["state"].upcase))
             order_ship_address.state = state
           else
             order_ship_address.state_name = ship_address["state"]

--- a/app/models/spree/billing_integration/paypal_express.rb
+++ b/app/models/spree/billing_integration/paypal_express.rb
@@ -7,6 +7,10 @@ class Spree::BillingIntegration::PaypalExpress < Spree::BillingIntegration
   preference :currency, :string, :default => 'USD'
   preference :allow_guest_checkout, :boolean, :default => false
 
+  attr_accessible :preferred_login, :preferred_password, :preferred_signature,
+	  :preferred_review, :preferred_no_shipping, :preferred_currency,
+	  :preferred_allow_guest_checkout, :preferred_server, :preferred_test_mode
+
   def provider_class
     ActiveMerchant::Billing::PaypalExpressGateway
   end

--- a/app/models/spree/billing_integration/paypal_express_uk.rb
+++ b/app/models/spree/billing_integration/paypal_express_uk.rb
@@ -5,6 +5,9 @@ class Spree::BillingIntegration::PaypalExpressUk < Spree::BillingIntegration
   preference :review, :boolean, :default => false
   preference :no_shipping, :boolean, :default => false
 
+  attr_accessible :preferred_login, :preferred_password, :preferred_signature,
+	  :preferred_review, :preferred_no_shipping, :preferred_server, :preferred_test_mode
+
   def provider_class
     ActiveMerchant::Billing::PaypalExpressUkGateway
   end

--- a/app/models/spree/log_entry_decorator.rb
+++ b/app/models/spree/log_entry_decorator.rb
@@ -1,0 +1,3 @@
+Spree::LogEntry.class_eval do
+  attr_accessible :details
+end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,0 +1,3 @@
+Spree::Payment.class_eval do 
+  attr_accessible :source, :source_type, :response_code, :avs_response, :details
+end

--- a/app/models/spree/paypal_account.rb
+++ b/app/models/spree/paypal_account.rb
@@ -1,4 +1,5 @@
 class Spree::PaypalAccount < ActiveRecord::Base
+  attr_accessible :email, :payer_id, :payer_country, :payer_status
   has_many :payments, :as => :source
 
   def actions

--- a/app/views/spree/admin/paypal_payments/refund.html.erb
+++ b/app/views/spree/admin/paypal_payments/refund.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'admin/shared/order_tabs', :locals => {:current => "Payments"} %>
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => {:current => "Payments"} %>
 
 <% form_tag do %>
 

--- a/app/views/spree/shared/paypal_express_confirm.html.erb
+++ b/app/views/spree/shared/paypal_express_confirm.html.erb
@@ -3,7 +3,7 @@
   <%= raw t("order_not_yet_placed") %>
 </p>
 
-<%= render :partial => 'shared/order_details', :locals => {:order => @order} -%>
+<%= render :partial => 'spree/shared/order_details', :locals => {:order => @order} -%>
 <div class="form-buttons">
   <%= button_to t('place_order'), paypal_finish_order_checkout_url(@order, {:token => params[:token] , :PayerID => params[:PayerID], :payment_method_id =>
   params[:payment_method_id] } ), :class => "button primary" %>


### PR DESCRIPTION
If one has enabled the confirm state in paypal express settings, then the `paypal_confirm` view is shown.
In this view the `@order.state` is `payment`, instead of `confirm`.

This patch fixes that.
