### PR TITLE
Set attr_accessible to allow updating payment method settings

### DIFF
--- a/app/models/spree/billing_integration/paypal_express.rb
+++ b/app/models/spree/billing_integration/paypal_express.rb
@@ -7,6 +7,10 @@ class Spree::BillingIntegration::PaypalExpress < Spree::BillingIntegration
   preference :currency, :string, :default => 'USD'
   preference :allow_guest_checkout, :boolean, :default => false
 
+  attr_accessible :preferred_login, :preferred_password, :preferred_signature,
+	  :preferred_review, :preferred_no_shipping, :preferred_currency,
+	  :preferred_allow_guest_checkout, :preferred_server, :preferred_test_mode
+
   def provider_class
     ActiveMerchant::Billing::PaypalExpressGateway
   end

--- a/app/models/spree/billing_integration/paypal_express_uk.rb
+++ b/app/models/spree/billing_integration/paypal_express_uk.rb
@@ -5,6 +5,9 @@ class Spree::BillingIntegration::PaypalExpressUk < Spree::BillingIntegration
   preference :review, :boolean, :default => false
   preference :no_shipping, :boolean, :default => false
 
+  attr_accessible :preferred_login, :preferred_password, :preferred_signature,
+	  :preferred_review, :preferred_no_shipping, :preferred_server, :preferred_test_mode
+
   def provider_class
     ActiveMerchant::Billing::PaypalExpressUkGateway
   end


### PR DESCRIPTION
This was fixed on master with 2c12f396678149239dc8a4cba2bb8882876a842a, but not on the 1-0 branch.
