### PR TITLE
fixed bug where state not found is Paypal returns state abbr in lowercase

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -80,7 +80,7 @@ module Spree
                                                   # phone is currently blanked in AM's PPX response lib
                                                   :phone      => @ppx_details.params["phone"] || "(not given)"
 
-          if (state = Spree::State.find_by_abbr(ship_address["state"]))
+          if (state = Spree::State.find_by_abbr(ship_address["state"].upcase))
             order_ship_address.state = state
           else
             order_ship_address.state_name = ship_address["state"]


### PR DESCRIPTION
Paypal returned a state abbreviation in lowercase and the payment errored out because we weren't able to find the state.

This branch works in that case.

We're on Heroku using Postgres
