### PR TITLE
Show Spree SKU in Paypal Express order pipeline / confirmation emails

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -189,7 +189,7 @@ module Spree
           fire_event('spree.checkout.coupon_code_added', :coupon_code => @order.coupon_code)
         end
       end
-      
+
       load_order
       payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
 
@@ -238,7 +238,7 @@ module Spree
         price = (item.price * 100).to_i # convert for gateway
         { :name        => item.variant.product.name,
           :description => (item.variant.product.description[0..120] if item.variant.product.description),
-          :sku         => item.variant.sku,
+          :number      => item.variant.sku,
           :quantity    => item.quantity,
           :amount      => price,
           :weight      => item.variant.weight,


### PR DESCRIPTION
ActiveMerchant::PaypalExpressGateway does nothing with item[:sku], instead we should set the confusingly-named item[:number](name corresponds to the underlying Paypal api: https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_ECCustomizing)
