### PR TITLE
Translate errors del gateway paypal express

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -365,8 +365,10 @@ module Spree
       else
         text = response.to_s
       end
-
-      msg = "#{I18n.t('gateway_error')}: #{text}"
+	  #Con esta línea de código convertimos una línea de texto en el formato de los locale
+	  text = text.parameterize(sep = '_')
+	  #Se agrega la el metodo para la traducción
+      msg = "#{I18n.t('gateway_error')}: #{I18n.t(text)}"      
       logger.error(msg)
       flash[:error] = msg
     end


### PR DESCRIPTION
II've been testing spree in my local machine, let me mention that spree is a great project. I add paypal express gateway. 
The point is that no matter which locale is used, if there are errors will be shown in English as it is in this way as the gateway paypal express delivery. 
Thus I think you can translate the errors the gateway of paypal express delivery. 

I did a test by changing the file spree_paypal_express\app\controllers\spree\checkout_controller_decorator.rb
def gateway_error (response)
       if response.is_a? ActiveMerchant :: Billing :: Response
         response.params text = ['message'] | |
                response.params ['response_reason_text'] | |
                response.message
       else
         text = response.to_s
       end
  ++ text = text.parameterize (sep = '_')++
  ++ msg = "# {I18n.t ('gateway_error')}: # {I18n.t (text)}"++
       logger.error (msg)
       flash [: error] = msg
     end
Whereas it should add items in the locale
## e.g. 

es-MX:
 a_match_of_the_shipping_address_city_state_and_postal_code_failed: 'Falló la coincidencia de la dirección de envio, Ciudad, Estado, y Código Postal'
  devise:
 .............................................
 ..............................................
a_match_of_the_shipping_address_city_state_and_postal_code_failed 
This is a result have changed the error message that provides the gateway in a camel-like format, so that each of the messages in this format should transform to later add to the locale.

https://cms.paypal.com/mx/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_nvp_errorcodes link to the messages error list.
