### PR TITLE
Add billing address to paypal options

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -390,6 +390,17 @@ module Spree
 
       # suggest current user's email or any email stored in the order
       opts[:email] = spree_current_user ? spree_current_user.email : order.email
+      opts[:address_override] = 1
+      opts[:address] = {
+        :name => order.bill_address.full_name,
+        :zip => order.bill_address.zipcode,
+        :address1 => order.bill_address.address1,
+        :address2 => order.bill_address.address2,
+        :city => order.bill_address.city,
+        :phone => order.bill_address.phone,
+        :state => order.bill_address.state_text,
+        :country => order.bill_address.country.iso
+      }
 
       opts
     end


### PR DESCRIPTION
With this change, the Customer's full billing address details are submitted to the Paypal express gateway, allowing the Guest Form on paypal's side to be pre-filled with information that they already entered during the checkout process.

It eliminates the extra steps and shopping cart fatigue
