### PR TITLE
Fixes the error "bad component(expected host component): localhost:3000"

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -192,7 +192,12 @@ module Spree
     private
 
     def asset_url(_path)
-      URI::HTTP.build(:path => ActionController::Base.helpers.asset_path(_path), :host => Spree::Config[:site_url].strip).to_s
+      host = Spree::Config[:site_url].strip
+      unless host.match /https?:\/\//
+          host = "http://#{host}"
+      end
+      uri = URI.parse(host)
+      URI::HTTP.build(:path => ActionController::Base.helpers.asset_path(_path), :host => uri.host, :port => (uri.port || 80)).to_s
     end
 
     def record_log(payment, response)


### PR DESCRIPTION
This commit fixes the error

```
bad component(expected host component): localhost:3000
```

raised from `Spree::CheckoutController.asset_url` when the `Spree::Config[:site_url]` variable contains the port, e.g. in development machines which uses port 3000
