### PR TITLE
Make the admin view work again after admin/api has been refactored.

### DIFF
--- a/app/views/spree/admin/payments/source_forms/_paypalexpress.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_paypalexpress.html.erb
@@ -1,8 +1,8 @@
 <% content_for :head do %>
   <script type="text/javascript">
-    jQuery(document).ready(function(){
+    $(window).load(function() {
       $("label:contains('<%= payment_method.name %>')").hide();
-      $("label:contains('<%= payment_method.name %>') input").disable();
+      $("label:contains('<%= payment_method.name %>') input").attr('disabled', true);
     });
   </script>
 <% end %>

--- a/app/views/spree/admin/payments/source_forms/_paypalexpressuk.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_paypalexpressuk.html.erb
@@ -1,8 +1,8 @@
 <% content_for :head do %>
   <script type="text/javascript">
-    jQuery(document).ready(function(){
+    $(window).load(function() {
       $("label:contains('<%= payment_method.name %>')").hide();
-      $("label:contains('<%= payment_method.name %>') input").disable();
+      $("label:contains('<%= payment_method.name %>') input").attr('disabled', true);
     });
   </script>
 <% end %>


### PR DESCRIPTION
This PR should make sure the admin section, where admin's can manually create payments for an order, works properly again.
- Disable doesn't work for radio buttons …
- After API refactoring the input items are not shown on document ready, therefor the even doesn't hide/disable them.
