### PR TITLE
Fix: Do not redirect to paypal if there is an error on the Order model

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -218,6 +218,10 @@ module Spree
       end
 
       load_order
+      if not @order.errors.empty?
+         render :edit and return
+      end
+
       payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
 
       if payment_method.kind_of?(Spree::BillingIntegration::PaypalExpress) || payment_method.kind_of?(Spree::BillingIntegration::PaypalExpressUk)


### PR DESCRIPTION
In case there is a validation issue with the Spree::Order we do not
want to redirect to the paypal page but resolve the error.
