### PR TITLE
Duplicate payments created for non paypal payment methods.

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -203,6 +203,9 @@ module Spree
       return unless (params[:state] == "payment")
       return unless params[:order][:payments_attributes]
 
+      payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
+      return unless payment_method.kind_of?(Spree::BillingIntegration::PaypalExpress) || payment_method.kind_of?(Spree::BillingIntegration::PaypalExpressUk)
+
       if @order.update_attributes(object_params)
         fire_event('spree.checkout.update')
         render :edit and return unless apply_coupon_code
@@ -213,11 +216,7 @@ module Spree
          render :edit and return
       end
 
-      payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
-
-      if payment_method.kind_of?(Spree::BillingIntegration::PaypalExpress) || payment_method.kind_of?(Spree::BillingIntegration::PaypalExpressUk)
-        redirect_to(paypal_payment_order_checkout_url(@order, :payment_method_id => payment_method.id)) and return
-      end
+      redirect_to(paypal_payment_order_checkout_url(@order, :payment_method_id => payment_method.id)) and return
     end
 
     def fixed_opts


### PR DESCRIPTION
We recently noticed a duplicate payment were being created when using a credit card payment method on a site we have updated. I tracked it down to the checkout controller decorator for paypal express, specifically updating attributes on the order object before checking if the payment type is paypal...
Updating the order object uses accepts_nested_attributes_for the payment details, so when called on in the checkout controller decorator it creates a payment for the order. The code then continues, checks if the payment method is paypal, which is isnt, and bails out of the filter continuing to update action. The update action then updates the order object again, and due to the nested attributes not being associated with the payment object's id that was created in the checkout controller decorator, it goes ahead and creates a whole new payment for the order, which of course is a duplicate.

The fix is very simple, I have just modified the controller filter to check the type of payment method before the order is updated, if it isn't paypal the method bails out and allows the update action to create the payment instead.
