### PR TITLE
Preventing duplicate payment record stuck at the checkout state...

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -206,7 +206,9 @@ module Spree
       payment_method = Spree::PaymentMethod.find(params[:order][:payments_attributes].first[:payment_method_id])
       return unless payment_method.kind_of?(Spree::BillingIntegration::PaypalExpress) || payment_method.kind_of?(Spree::BillingIntegration::PaypalExpressUk)
 
-      if @order.update_attributes(object_params)
+      update_params = object_params.dup
+      update_params.delete(:payments_attributes)
+      if @order.update_attributes(update_params)
         fire_event('spree.checkout.update')
         render :edit and return unless apply_coupon_code
       end


### PR DESCRIPTION
When placing an order with a successful transaction via paypal we noticed that a duplicate payment record was created. The duplicate was also stuck in the checkout state. After investigating I found that the two payment records were created at two different times in the process, both in the checkout controller decorator. The first payment is created during the test to see if we should redirect to paypal (redirect_to_paypal_express_form_if_needed) when the objects params are updated. The second is created during the paypal_finish method.

The payment created in the paypal_finish method seems to be the genuine payment, so I left that as it is. The payment created during the check for paypal express seems to be a side effect of an upstream change in the spree_core project. It seems the payment record is created as a result of accepts_nested_attributes_for being used for payments in an order. To fix this I have removed the payments_attributes from the params being sent to the orders update_attributes method.

Also worth noting that this would of also served as a fix for a PR I sent last friday... https://github.com/spree/spree_paypal_express/pull/129 However I havent reverted any changes I made for that PR as the check being performed in that code may help prevent future bugs. 
