### PR TITLE
Changing to order.payment? since order.payment was removed

### DIFF
--- a/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
@@ -2,7 +2,7 @@
   insert_bottom '.payment-info'
   original 'cd012ef486088f2543371329dde5d4f8f3d4191b' 
 -->
-<% if order.payment && order.payment.source.class.to_s == 'Spree::PaypalAccount' %>
+<% if order.payment? && order.payment.source.class.to_s == 'Spree::PaypalAccount' %>
   <span class="cc-type">
     <%= image_tag "paypal.png" %>
     <%= t("paypal_payer_statuses.#{order.payment.source.payer_status.to_s}").capitalize %>

--- a/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
@@ -2,7 +2,7 @@
   insert_bottom '.payment-info'
   original 'cd012ef486088f2543371329dde5d4f8f3d4191b' 
 -->
-<% if order.payment? && order.payment.source.class.to_s == 'Spree::PaypalAccount' %>
+<% if order.payment? && order.payments.any? { |source| source.source_type == 'Spree::PaypalAccount' } %>
   <span class="cc-type">
     <%= image_tag "paypal.png" %>
     <%= t("paypal_payer_statuses.#{order.payment.source.payer_status.to_s}").capitalize %>


### PR DESCRIPTION
Order#payment was removed in https://github.com/spree/spree/commit/3d0fa4ff434569ff8491aba690fde87e577ec19c

Since add_paypal_details override only uses it for a boolean test, I changed to payment?

This needs to change in master as well
