### PR TITLE
Fixes #84

### DIFF
--- a/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/add_paypal_details.html.erb.deface
@@ -2,13 +2,17 @@
   insert_bottom '.payment-info'
   original 'cd012ef486088f2543371329dde5d4f8f3d4191b' 
 -->
-<% if order.payments.present? && order.payments.any? { |source| source.source_type == 'Spree::PaypalAccount' } %>
-  <span class="cc-type">
-    <%= image_tag "paypal.png" %>
-    <%= t("paypal_payer_statuses.#{order.payment.source.payer_status.to_s}").capitalize %>
-  </span>
-  <br />
-  <span class="full-name">
-    <%= order.payment.source.email %>
-  </span>
-<% end %>
+  <% order.payments.each do |payment| %>
+    <% if (payment.source_type == 'Spree::PaypalAccount') %>
+      <span class="cc-type">
+        <%= image_tag "paypal.png" %>
+        <%= t("paypal_payer_statuses.#{payment.source.payer_status.to_s}").capitalize %>
+      </span>
+      <br />
+      <span class="full-name">
+      <%= payment.source.email %>
+      </span>
+    <% end %>
+  <% end %>
+
+

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.has_rdoc      = false
 
-  s.add_dependency 'spree_core', '~> 1.3.0'
+  s.add_dependency 'spree_core', '~> 1.3.x'
 
   s.add_development_dependency 'capybara', '~> 1.1.3'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
This pull request changes the order details deface. Previously the file was still referring to `order.payment` in two places, even after https://github.com/spree/spree_paypal_express/commit/020d519357d0c68bb11acd525ba2a2f8c316dc22
This fix isn't particularly graceful, as I'm new to ruby, but it does the trick; i.e. after paypal redirects back to my spree store, it doesn't show an error page saying that it can't find the order.payment method.
