### PR TITLE
Paypal express button on cart step

### DIFF
--- a/app/overrides/spree/orders/edit/add_paypalexpress_button.html.erb.deface
+++ b/app/overrides/spree/orders/edit/add_paypalexpress_button.html.erb.deface
@@ -1,0 +1,5 @@
+<!--
+  insert_bottom '[data-hook=cart_buttons]'
+-->
+  <%= render :partial => 'spree/orders/cart_paypalexpress_button' %>
+

--- a/app/views/spree/orders/_cart_paypalexpress_button.html.erb
+++ b/app/views/spree/orders/_cart_paypalexpress_button.html.erb
@@ -1,0 +1,10 @@
+  <% @order.available_payment_methods.each do |payment_method| %>
+    <% if payment_method.method_type.start_with?('paypalexpress') and payment_method.preferred_cart_checkout %>
+      <a href="<%= paypal_payment_order_checkout_url @order, :payment_method_id => payment_method.id %>">
+        <img src="https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif" />
+      </a>
+    <% end %>
+  <% end %>
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Spree::Core::Engine.routes.draw do
 
   match '/paypal_notify' => 'paypal_express_callbacks#notify', :via => [:get, :post]
 
-  match '/paypal_shipping_update' => 'paypal_express_callbacks#shipping_estimate', :via => :post
+  match '/paypal_shipping_update/:id' => 'paypal_express_callbacks#shipping_estimate', :via => :post
 
   namespace :admin do
     resources :orders do


### PR DESCRIPTION
Fix issues with shipping & tax calculations
Added override to add paypal button on cart step (when enabled)
Use paypal account email for order email for checkout on cart step
Fix issues with paypal express with Spree::Auth[:registration_step] = false
