### PR TITLE
Place Order translation missing breaks Place Order button HTML

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -11,6 +11,7 @@ de:
   order_not_yet_placed: "Ihre Bestellung wurde <strong>NICHT</strong> abgeschlossen werden, bitte überprüfen sie die Details und klicken erneut <strong>Bestellung abschließen</strong>."
   paypal_payment_id: PayPal Zahlungs ID
   pending_reason: Pending Reason
+  place_order: Bestellung abschließen
   result: Ergebnis
   review: Bewertung
   no_shipping: Keine Versandkosten

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -9,6 +9,7 @@ en-GB:
   order_not_yet_placed: "Your order has <strong>NOT</strong> been be placed, please review the details and click <strong>Place Order</strong> below to finalize your order."
   paypal_payment_id: PayPal Payment ID
   pending_reason: Pending Reason
+  place_order: Place Order
   result: Result
   review: Review
   no_shipping: No Shipping

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
   order_not_yet_placed: "Your order has <strong>NOT</strong> been be placed, please review the details and click <strong>Place Order</strong> below to finalize your order."
   paypal_payment_id: PayPal Payment ID
   pending_reason: Pending Reason
+  place_order: Place Order
   result: Result
   review: Review
   no_shipping: No Shipping

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,37 @@
 ---
 es:
+  ipn_transaction: Transacción IPN
+  unknown_transaction: Transacción desconocida
+  edit_paypal_info: Editar pago PayPal Express
+  paypal_payment: Pago PayPal Express
+  paypal_txn_id: Código de transacción
+  paypal_capture_complete: La transacción PayPal ha sido capturada
+  unable_to_capture_paypal: No se puede capturar la transacción PayPal
+  signature: Signatura
+  order_not_yet_placed: "Tu pedido <strong>NO</strong> se ha completado, por favor revisa los detalles y haz click en <strong>Hacer Pedido</strong> debajo para finalizar tu pedido."
+  paypal_payment_id: ID del pago PayPal
+  pending_reason: Razón pendiente
+  place_order: Hacer Pedido
+  result: Resultado
+  review: Revisar
+  no_shipping: Sin envío
+  cart_checkout: Pedido desde carrito
+  paypal_account: Cuenta PayPal
+  payer_id: ID del pagador
+  payer_country: País
+  payer_status: Estado
   paypal_payer_statuses:
     verified: verificado
     unverified: no verificado
+  comment: Comentario
+  account_details: Detalles de cuenta
+  finalize:
+    paypalexpress: Capturar Pago
+  activerecord:
+     attributes:
+       paypal_payment:
+         amount: Cantidad
+     models:
+       paypal_payment:
+         one: Pago PayPal
+         other: Pagos PayPal


### PR DESCRIPTION
When `Review` checkbox was checked in the admin section for Payment Methods/Paypal Express, the `Place Order` translation in the `Confirm Page` was missing, making the button look bad.

The translation was added for all locales (en, en-GB, de, es).
