### PR TITLE
Minor version and locale fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'http://rubygems.org'
-gem 'spree', :github => 'spree/spree' # temporarily here until 2.0.0.beta is released
+gem 'spree', :github => 'spree/spree', :branch => '2-0-stable'
 gemspec

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,4 @@ en:
        paypal_payment:
          one: PayPal Payment
          other: PayPal Payments
+  order_processed_successfully: Order Processed Successfully


### PR DESCRIPTION
Update Spree version reference to match 2-0-stable.
Add missing translation entry for message after successful PayPal purchase.
